### PR TITLE
Appdx-pycoin Litecoin Equivalent?

### DIFF
--- a/appdx-pycoin.asciidoc
+++ b/appdx-pycoin.asciidoc
@@ -1,6 +1,6 @@
 [[appdx-pycoin]]
 [appendix]
-== pycoin, ku, and tx
+== pycoin, ku, and tx 
 
 
 ((("pycoin library")))The Python library http://github.com/richardkiss/pycoin[+pycoin+], originally written and maintained by Richard Kiss, is a Python-based library that supports manipulation of bitcoin keys and transactions, even supporting the scripting language enough to properly deal with nonstandard transactions.


### PR DESCRIPTION
If there isn't a litecoin equivalent, we can delete this appendix.  Need to also remove it under book.asciidoc, atlas.json, ch.3, and code/pycoin_example.py